### PR TITLE
Fix/org tests

### DIFF
--- a/Dockerfile-Test
+++ b/Dockerfile-Test
@@ -4,7 +4,7 @@ ENV MMS5_ROOT_CONTEXT http://layer1-service
 ENV MMS5_QUERY_URL http://quad-server:3030/ds/sparql
 ENV MMS5_UPDATE_URL http://quad-server:3030/ds/update
 ENV MMS5_GRAPH_STORE_PROTOCOL_URL http://quad-server:3030/ds/data
-ENV MMS5_LOAD_SERVICE_URL http://load-service:8081/store
+ENV MMS5_LOAD_SERVICE_URL http://store-service:8081/store
 COPY . .
 RUN apt-get update && apt-get install -y procps
 ENTRYPOINT ["/application/gradlew", "test"]

--- a/Dockerfile-Test
+++ b/Dockerfile-Test
@@ -4,6 +4,7 @@ ENV MMS5_ROOT_CONTEXT http://layer1-service
 ENV MMS5_QUERY_URL http://quad-server:3030/ds/sparql
 ENV MMS5_UPDATE_URL http://quad-server:3030/ds/update
 ENV MMS5_GRAPH_STORE_PROTOCOL_URL http://quad-server:3030/ds/data
+ENV MMS5_LOAD_SERVICE_URL http://load-service:8081/store
 COPY . .
 RUN apt-get update && apt-get install -y procps
 ENTRYPOINT ["/application/gradlew", "test"]

--- a/Dockerfile-Test
+++ b/Dockerfile-Test
@@ -1,8 +1,6 @@
 FROM openjdk:17.0.2-jdk-slim as build
 WORKDIR application
 ENV MMS5_ROOT_CONTEXT http://layer1-service
-ENV MMS5_LOAD_SERVICE_URL http://store-service:8081/store
-ENV MMS5_QUAD_STORE_URL http://quad-server:3030/ds/sparql
 ENV MMS5_QUERY_URL http://quad-server:3030/ds/sparql
 ENV MMS5_UPDATE_URL http://quad-server:3030/ds/update
 ENV MMS5_GRAPH_STORE_PROTOCOL_URL http://quad-server:3030/ds/data

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,11 +82,10 @@ tasks {
             this.showStandardStreams = true
         }
         environment("MMS5_ROOT_CONTEXT", System.getenv("MMS5_ROOT_CONTEXT"))
-        environment("MMS5_LOAD_SERVICE_URL", System.getenv("MMS5_LOAD_SERVICE_URL"))
-        environment("MMS5_QUAD_STORE_URL", System.getenv("MMS5_QUAD_STORE_URL"))
         environment("MMS5_QUERY_URL", System.getenv("MMS5_QUERY_URL"))
         environment("MMS5_UPDATE_URL", System.getenv("MMS5_UPDATE_URL"))
         environment("MMS5_GRAPH_STORE_PROTOCOL_URL", System.getenv("MMS5_GRAPH_STORE_PROTOCOL_URL"))
+        environment("MMS5_LOAD_SERVICE_URL", System.getenv("MMS5_LOAD_SERVICE_URL"))
     }
     register<Copy>("copy-test-fuseki-server") {
         // Copy fuseki-server jar to known location (build/test-fuseki-server)

--- a/src/main/kotlin/org/openmbee/mms5/Namespaces.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Namespaces.kt
@@ -210,6 +210,8 @@ object MMS {
     val Group = ResourceFactory.createResource("${BASE}Group")
     val Policy = ResourceFactory.createResource("${BASE}Policy")
 
+    val Transaction = ResourceFactory.createResource("${BASE}Transaction")
+
 
     val RepoMetadataGraph = ResourceFactory.createResource("${BASE}RepoMetadataGraph")
     val CollectionMetadataGraph = ResourceFactory.createResource("${BASE}CollectionMetadataGraph")
@@ -237,6 +239,9 @@ object MMS {
 
     val srcRef = ResourceFactory.createProperty(BASE, "srcRef")
     val dstRef = ResourceFactory.createProperty(BASE, "dstRef")
+
+    val scope = ResourceFactory.createProperty(BASE, "scope")
+    val role = ResourceFactory.createProperty(BASE, "role")
 
     val etag = ResourceFactory.createProperty(BASE, "etag")
     val ref = ResourceFactory.createProperty(BASE, "ref")

--- a/src/main/kotlin/org/openmbee/mms5/routes/BranchCreate.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/BranchCreate.kt
@@ -18,8 +18,8 @@ private val DEFAULT_CONDITIONS = REPO_CRUD_CONDITIONS.append {
 
         """
             # branch must not yet exist
-            graph mor-graph:Metadata {
-                filter not exists {
+            filter not exists {
+                graph mor-graph:Metadata {
                     morb: a mms:Branch .
                 }
             }

--- a/src/main/kotlin/org/openmbee/mms5/routes/OrgCreate.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/OrgCreate.kt
@@ -17,8 +17,8 @@ private val DEFAULT_CONDITIONS = GLOBAL_CRUD_CONDITIONS.append {
 
         """
             # org must not yet exist
-            graph m-graph:Cluster {
-                filter not exists {
+            filter not exists {
+                graph m-graph:Cluster {
                     mo: a mms:Org .
                 }
             }

--- a/src/main/kotlin/org/openmbee/mms5/routes/RepoCreate.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/RepoCreate.kt
@@ -17,8 +17,8 @@ private val DEFAULT_CONDITIONS = ORG_CRUD_CONDITIONS.append {
 
         """
             # repo must not yet exist
-            graph m-graph:Cluster {
-                filter not exists {
+            filter not exists {
+                graph m-graph:Cluster {
                     mor: a mms:Repo .
                 }
             }
@@ -31,8 +31,8 @@ private val DEFAULT_CONDITIONS = ORG_CRUD_CONDITIONS.append {
 
         """
             # metadata graph must not yet exist
-            graph m-graph:Graphs {
-                filter not exists {
+            filter not exists {
+                graph m-graph:Graphs {
                     mor-graph:Metadata a mms:RepoMetadataGraph .
                 }
             }
@@ -45,8 +45,8 @@ private val DEFAULT_CONDITIONS = ORG_CRUD_CONDITIONS.append {
 
         """
             # repo metadata graph must be empty
-            graph mor-graph:Metadata {
-                filter not exists {
+            filter not exists {
+                graph mor-graph:Metadata {
                     ?e_s ?e_p ?e_o .
                 }
             }

--- a/src/main/resources/application.conf.example
+++ b/src/main/resources/application.conf.example
@@ -1,6 +1,6 @@
 mms {
     load-service {
-        url = "https://mms-domain/loader"
+        url = "https://load-service-domain/loader"
         url = ${?MMS5_LOAD_SERVICE_URL}
     }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />
     </root>
+    <logger name="org.apache.jena.sparql" level="WARN"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <!-- Import loggers configuration from external file -->

--- a/src/test/kotlin/org/openmbee/mms5/OrgAny.kt
+++ b/src/test/kotlin/org/openmbee/mms5/OrgAny.kt
@@ -4,7 +4,9 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
+import org.apache.jena.vocabulary.XSD
 import org.openmbee.mms5.util.*
+import org.slf4j.LoggerFactory
 
 fun TriplesAsserter.validateOrgTriples(
     createResponse: TestApplicationResponse,
@@ -14,6 +16,7 @@ fun TriplesAsserter.validateOrgTriples(
 ) {
     val orgPath = localIri("/orgs/$orgId")
 
+    // org triples
     subject(orgPath) {
         exclusivelyHas(
             RDF.type exactly MMS.Org,
@@ -23,9 +26,30 @@ fun TriplesAsserter.validateOrgTriples(
             *extraPatterns.toTypedArray()
         )
     }
+
+    // auto policy
+    matchOneSubjectTerseByPrefix("m-policy:AutoOrgOwner") {
+        includes(
+            RDF.type exactly MMS.Policy,
+        )
+    }
+
+    // transaction
+    subjectTerse("mt:") {
+        includes(
+            RDF.type exactly MMS.Transaction,
+            MMS.created hasDatatype XSD.dateTime,
+            MMS.org exactly orgPath.iri,
+        )
+    }
+
+    // inspect
+    subject("urn:mms:inspect") { ignoreAll() }
 }
 
 open class OrgAny: CommonSpec() {
+    open val logger = LoggerFactory.getLogger(RepoUpdate::class.java)
+
     val orgId = "open-mbee"
     val orgName = "OpenMBEE"
     val orgPath = "/orgs/$orgId"
@@ -37,6 +61,9 @@ open class OrgAny: CommonSpec() {
     val orgBarId = "bar-org"
     val orgBarName = "Bar Org"
     val orgBarPath = "/orgs/$orgBarId"
+
+    val arbitraryPropertyIri = "https://demo.org/custom/prop"
+    val arbitraryPropertyValue = "test"
 
     val validOrgBody = """
         <> dct:title "$orgName"@en .

--- a/src/test/kotlin/org/openmbee/mms5/OrgCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/OrgCreate.kt
@@ -1,5 +1,6 @@
 package org.openmbee.mms5
 
+import io.kotest.assertions.fail
 import io.kotest.assertions.ktor.shouldHaveHeader
 import io.kotest.assertions.ktor.shouldHaveStatus
 import io.kotest.matchers.string.shouldNotBeBlank

--- a/src/test/kotlin/org/openmbee/mms5/OrgCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/OrgCreate.kt
@@ -20,6 +20,25 @@ class OrgCreate : OrgAny() {
             }
         }
 
+        mapOf(
+            "rdf:type" to "mms:NotOrg",
+            "mms:id" to "\"not-$orgId\"",
+            "mms:etag" to "\"${UUID.randomUUID()}\"",
+        ).forEach { (pred, obj) ->
+            "reject wrong $pred" {
+                withTest {
+                    httpPut(orgPath) {
+                        setTurtleBody("""
+                            $validOrgBody
+                            <> $pred $obj .
+                        """.trimIndent())
+                    }.apply {
+                        response shouldHaveStatus HttpStatusCode.BadRequest
+                    }
+                }
+            }
+        }
+
         "create valid org" {
             withTest {
                 httpPut(orgPath) {

--- a/src/test/kotlin/org/openmbee/mms5/OrgRead.kt
+++ b/src/test/kotlin/org/openmbee/mms5/OrgRead.kt
@@ -108,6 +108,8 @@ class OrgRead : OrgAny() {
                 httpGet("/orgs") {}.apply {
                     response shouldHaveStatus HttpStatusCode.OK
 
+                    logger.info(response.content)
+
                     response.exclusivelyHasTriples {
                         modelName = it
 

--- a/src/test/kotlin/org/openmbee/mms5/RepoAny.kt
+++ b/src/test/kotlin/org/openmbee/mms5/RepoAny.kt
@@ -1,23 +1,17 @@
 package org.openmbee.mms5
 
 import io.kotest.core.test.TestCase
+import org.apache.jena.http.HttpOp.httpGet
 import org.openmbee.mms5.util.CommonSpec
 import org.openmbee.mms5.util.createOrg
 import org.slf4j.LoggerFactory
 
-open class RepoAny : CommonSpec() {
-    val logger = LoggerFactory.getLogger(RepoUpdate::class.java)
-
-    val orgId = "base-org"
-    val orgPath = "/orgs/$orgId"
-    val orgName = "Base Org"
+open class RepoAny : OrgAny() {
+    override val logger = LoggerFactory.getLogger(RepoUpdate::class.java)
 
     val repoId = "new-repo"
     val repoName = "New Repo"
     val repoPath = "$orgPath/repos/$repoId"
-
-    val arbitraryPropertyIri = "https://demo.org/custom/prop"
-    val arbitraryPropertyValue = "test"
 
     val validRepoBody = """
         <> dct:title "$repoName"@en .
@@ -27,10 +21,7 @@ open class RepoAny : CommonSpec() {
     override suspend fun beforeEach(testCase: TestCase) {
         super.beforeEach(testCase)
 
-        logger.info("Creating org $orgId")
-
+        // create base org for repo test
         createOrg(orgId, orgName)
-
-        logger.info("done")
     }
 }

--- a/src/test/kotlin/org/openmbee/mms5/util/Common.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/Common.kt
@@ -38,7 +38,7 @@ open class CommonSpec() : StringSpec({
     }
 
     afterEach { it ->
-        val exportFile = File("/application/build/reports/tests/trig/${escapeFileName(it.a.name.testName)}.trig")
+        val exportFile = File("./build/reports/tests/trig/${escapeFileName(it.a.name.testName)}.trig")
 
         if (!exportFile.parentFile.exists())
             exportFile.parentFile.mkdirs()

--- a/src/test/kotlin/org/openmbee/mms5/util/Helper.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/Helper.kt
@@ -1,6 +1,7 @@
 package org.openmbee.mms5.util
 
 import io.kotest.assertions.ktor.shouldHaveStatus
+import io.kotest.matchers.shouldHave
 import io.ktor.server.testing.*
 
 
@@ -12,6 +13,11 @@ fun createOrg(orgId: String, orgName: String): TestApplicationCall {
             """.trimIndent())
         }.apply {
             response shouldHaveStatus 200
+
+            // assert it exists
+            httpGet("/orgs/$orgId") {}.apply {
+                response shouldHaveStatus 200
+            }
         }
     }
 }


### PR DESCRIPTION
 - Sets apache jena log level to WARN
 - Cleans up env vars
 - Fixes queries that use FILTER NOT EXISTS blocks when graph might not yet exist
 - Consolidates org properties
 - Adds data-driven test-case example
 - Fixes kotest hook overrides
 - Adds improvements to RDF content assertions including datatype, subject prefix matching, terse subjects, and cardinality restrictions