### PR TITLE
fix: return 404 when at least one condition is a NotFound

### DIFF
--- a/src/main/kotlin/org/openmbee/mms5/Conditions.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Conditions.kt
@@ -261,12 +261,20 @@ class ConditionsGroup(var conditions: List<Condition>) {
         }
 
         if(failedConditions.isNotEmpty()) {
+            // a single condition was not met
             if(failedConditions.size == 1) {
                 val (msg, code) = failedConditions[0]
 
                 throw HttpException(msg, code)
             }
+            // multiple conditions failed
             else {
+                // give precedence to 404
+                failedConditions.find { it.second === HttpStatusCode.NotFound }?.let {
+                    throw HttpException(it.first, it.second)
+                }
+
+                // bundle
                 throw RequirementsNotMetException(failedConditions.map { it.first})
             }
         }

--- a/src/main/kotlin/org/openmbee/mms5/Model.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Model.kt
@@ -428,7 +428,7 @@ suspend fun MmsL1Context.queryModel(inputQueryString: String, refIri: String, co
                             auth()
                         }
                         where {
-                            raw(*conditions.requiredPatterns())
+                            raw(conditions.unionInspectPatterns())
                         }
                     }
 

--- a/src/main/kotlin/org/openmbee/mms5/routes/endpoints/ModelQuery.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/endpoints/ModelQuery.kt
@@ -25,6 +25,5 @@ fun Route.queryModel() {
                 assertPreconditions(this) { "" }
             })
         }
-
     }
 }

--- a/src/test/kotlin/org/openmbee/mms5/ModelQuery.kt
+++ b/src/test/kotlin/org/openmbee/mms5/ModelQuery.kt
@@ -15,6 +15,7 @@ class ModelQuery : ModelAny() {
                 }
             }
         }
+
         "query result is different between master and branch" {
             commitModel(masterPath, sparqlUpdate)
             createBranch(repoPath, "master", branchId, branchName)
@@ -34,6 +35,7 @@ class ModelQuery : ModelAny() {
                 }
             }
         }
+
         "query result is different between master and lock" {
             commitModel(masterPath, sparqlUpdate)
             createLock(repoPath, masterPath, lockId)
@@ -53,6 +55,7 @@ class ModelQuery : ModelAny() {
                 }
             }
         }
+
         "query result is different between master and lock from model loads" {
             loadModel(masterPath, loadTurtle)
             createLock(repoPath, masterPath, lockId)
@@ -87,6 +90,16 @@ class ModelQuery : ModelAny() {
                     """.trimIndent())
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
+                }
+            }
+        }
+
+        "nothing exists" {
+            withTest {
+                httpPost("/orgs/not-exists/repos/not-exists/branches/not-exists/query") {
+                    setSparqlQueryBody(sparqlQueryNames)
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.NotFound
                 }
             }
         }


### PR DESCRIPTION
fixes #113 by giving return code precedence to 404 if any of the fail conditions contain a NotFound.