### PR TITLE
feat: support request timeout config property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:${ktorVersion}")
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-host-common:$ktorVersion")
+    implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
     implementation("io.ktor:ktor-server-locations:$ktorVersion")
     implementation("io.ktor:ktor-server-auth:$ktorVersion")
     implementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,6 +77,11 @@ Other Configs
 
     | `Default: 512`
 
+  MMS5_SPARQL_REQUEST_TIMEOUT
+    Timeout per request sent to the triplestore, in seconds.
+
+    | `Default: 1800`
+
 Generate the initialization file
 --------------------------------
 

--- a/src/main/kotlin/org/openmbee/mms5/Application.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Application.kt
@@ -61,5 +61,6 @@ val Application.gzipLiteralsLargerThanKib: Long?
  */
 val Application.requestTimeout: Long?
     get() = environment.config.propertyOrNull("mms.application.request-timeout")?.getString()?.toLongOrNull()
+        ?.let { it * 1000 }
 
 class AuthorizationRequiredException(message: String): Exception(message) {}

--- a/src/main/kotlin/org/openmbee/mms5/Application.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Application.kt
@@ -35,4 +35,7 @@ val Application.maximumLiteralSizeKib: Long?
 val Application.gzipLiteralsLargerThanKib: Long?
     get() = environment.config.propertyOrNull("mms.application.gzip-literals-larger-than-kib")?.getString()?.toLongOrNull()
 
+val Application.requestTimeout: Long?
+    get() = environment.config.propertyOrNull("mms.application.request-timeout")?.getString()?.toLongOrNull()
+
 class AuthorizationRequiredException(message: String): Exception(message) {}

--- a/src/main/kotlin/org/openmbee/mms5/Application.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Application.kt
@@ -14,27 +14,51 @@ fun Application.module(testing: Boolean=false) {
 }
 
 
+/**
+ * URL to submit SPARQL queries when user is performing read operation.
+ */
 val Application.quadStoreQueryUrl: String
     get() = environment.config.property("mms.quad-store.query-url").getString()
 
+/**
+ * URL to submit SPARQL updates when application is performing write operation.
+ */
 val Application.quadStoreUpdateUrl: String
     get() = environment.config.property("mms.quad-store.update-url").getString()
 
+/**
+ * URL to submit [Graph Store Protocol](https://www.w3.org/TR/sparql11-http-rdf-update/) requests.
+ */
 val Application.quadStoreGraphStoreProtocolUrl: String?
     get() = environment.config.propertyOrNull("mms.quad-store.graph-store-protocol-url")?.getString()?.ifEmpty { null }
 
+/**
+ * Optional URL to a compatible MMS-5 load service.
+ */
 val Application.loadServiceUrl: String?
     get() = environment.config.propertyOrNull("mms.load-service.url")?.getString()?.ifEmpty { null }
 
+/**
+ * If set to `true`, responds with 404 to users who are not authorized to view a resource even if it exists.
+ */
 val Application.glomarResponse: Boolean
     get() = "true" == environment.config.propertyOrNull("mms.application.glomar-response")?.getString()
 
+/**
+ * Sets a limit on the size of string literals to store directly in the commit history, in KiB.
+ */
 val Application.maximumLiteralSizeKib: Long?
     get() = environment.config.propertyOrNull("mms.application.maximum-literal-size-kib")?.getString()?.toLongOrNull()
 
+/**
+ * Applies gzip compression to literals stored in the commit history when they exceed the given size, in KiB.
+ */
 val Application.gzipLiteralsLargerThanKib: Long?
     get() = environment.config.propertyOrNull("mms.application.gzip-literals-larger-than-kib")?.getString()?.toLongOrNull()
 
+/**
+ * Timeout per request sent to the triplestore, in seconds.
+ */
 val Application.requestTimeout: Long?
     get() = environment.config.propertyOrNull("mms.application.request-timeout")?.getString()?.toLongOrNull()
 

--- a/src/main/kotlin/org/openmbee/mms5/MmsL1.kt
+++ b/src/main/kotlin/org/openmbee/mms5/MmsL1.kt
@@ -1,6 +1,9 @@
 package org.openmbee.mms5
 
 import com.linkedin.migz.MiGzOutputStream
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.client.request.*
@@ -31,7 +34,7 @@ import org.apache.jena.vocabulary.OWL
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.RDFS
 import org.openmbee.mms5.plugins.UserDetailsPrincipal
-import org.openmbee.mms5.plugins.client
+import org.openmbee.mms5.plugins.httpClient
 import java.io.ByteArrayOutputStream
 import java.util.*
 
@@ -411,6 +414,8 @@ class MmsL1Context(val call: ApplicationCall, val requestBody: String, val permi
     val requestMethod = call.request.httpMethod.value
     val requestBodyContentType = call.request.contentType().toString()
 
+    val defaultHttpClient = call.httpClient()
+
     val prefixes: PrefixMapBuilder
         get() = prefixesFor(
             userId = userId,
@@ -594,7 +599,7 @@ class MmsL1Context(val call: ApplicationCall, val requestBody: String, val permi
 
         log("Executing SPARQL Update:\n$sparql")
 
-        return handleSparqlResponse(client.post(call.application.quadStoreUpdateUrl) {
+        return handleSparqlResponse(defaultHttpClient.post(call.application.quadStoreUpdateUrl) {
             headers {
                 append(HttpHeaders.Accept, ContentType.Application.Json)
             }
@@ -616,7 +621,7 @@ class MmsL1Context(val call: ApplicationCall, val requestBody: String, val permi
 
         log("Executing SPARQL Query:\n$sparql")
 
-        return handleSparqlResponse(client.post(call.application.quadStoreQueryUrl) {
+        return handleSparqlResponse(defaultHttpClient.post(call.application.quadStoreQueryUrl) {
             headers {
                 append(HttpHeaders.Accept, acceptType)
             }

--- a/src/main/kotlin/org/openmbee/mms5/plugins/HTTP.kt
+++ b/src/main/kotlin/org/openmbee/mms5/plugins/HTTP.kt
@@ -2,6 +2,7 @@ package org.openmbee.mms5.plugins
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.callloging.*
 import io.ktor.server.plugins.conditionalheaders.*
 import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.defaultheaders.*
@@ -22,10 +23,11 @@ fun Application.configureHTTP() {
             cause.handle(call)
         }
         exception<Throwable> { call, cause ->
+            call.application.log.error("internal error", cause)
             call.respondText(cause.stackTraceToString(), status=HttpStatusCode.InternalServerError)
         }
     }
-
+    install(CallLogging)
     install(CORS) {
         allowMethod(HttpMethod.Options)
         allowMethod(HttpMethod.Put)

--- a/src/main/kotlin/org/openmbee/mms5/plugins/Routing.kt
+++ b/src/main/kotlin/org/openmbee/mms5/plugins/Routing.kt
@@ -3,6 +3,7 @@ package org.openmbee.mms5.plugins
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.client.*
+import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.http.*
@@ -17,19 +18,24 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.jvm.javaio.*
 import org.openmbee.mms5.RdfContentTypes
+import org.openmbee.mms5.requestTimeout
 import org.openmbee.mms5.routes.*
 import org.openmbee.mms5.routes.endpoints.*
 import org.openmbee.mms5.routes.gsp.readModel
 
 
-val client = HttpClient(CIO) {
-    install(ContentNegotiation) {
-        register(RdfContentTypes.Turtle, TextConverter())
-        register(RdfContentTypes.JsonLd, TextConverter())
-    }
+fun ApplicationCall.httpClient(timeoutOverride: Long? = null): HttpClient {
+    return HttpClient(CIO) {
+        install(ContentNegotiation) {
+            register(RdfContentTypes.Turtle, TextConverter())
+            register(RdfContentTypes.JsonLd, TextConverter())
+        }
 
-    engine {
-        requestTimeout = 30 * 60 * 1000 // timeout after 30 minutes
+        engine {
+            requestTimeout = timeoutOverride
+                ?: this@httpClient.application.requestTimeout
+                ?: (30 * 60 * 1000) // default timeout of 30 minutes
+        }
     }
 }
 

--- a/src/main/kotlin/org/openmbee/mms5/plugins/Routing.kt
+++ b/src/main/kotlin/org/openmbee/mms5/plugins/Routing.kt
@@ -24,7 +24,7 @@ import org.openmbee.mms5.routes.endpoints.*
 import org.openmbee.mms5.routes.gsp.readModel
 
 
-fun ApplicationCall.httpClient(timeoutOverride: Long? = null): HttpClient {
+fun ApplicationCall.httpClient(timeoutOverrideMs: Long? = null): HttpClient {
     return HttpClient(CIO) {
         install(ContentNegotiation) {
             register(RdfContentTypes.Turtle, TextConverter())
@@ -32,7 +32,7 @@ fun ApplicationCall.httpClient(timeoutOverride: Long? = null): HttpClient {
         }
 
         engine {
-            requestTimeout = timeoutOverride
+            requestTimeout = timeoutOverrideMs
                 ?: this@httpClient.application.requestTimeout
                 ?: (30 * 60 * 1000) // default timeout of 30 minutes
         }

--- a/src/main/kotlin/org/openmbee/mms5/routes/gsp/ModelLoad.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/gsp/ModelLoad.kt
@@ -16,7 +16,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.apache.jena.rdf.model.Property
 import org.apache.jena.rdf.model.Resource
 import org.openmbee.mms5.*
-import org.openmbee.mms5.plugins.client
 
 
 private val DEFAULT_UPDATE_CONDITIONS = BRANCH_COMMIT_CONDITIONS
@@ -25,7 +24,6 @@ private val DEFAULT_UPDATE_CONDITIONS = BRANCH_COMMIT_CONDITIONS
 fun Route.loadModel() {
     post("/orgs/{orgId}/repos/{repoId}/branches/{branchId}/graph") {
         call.mmsL1(Permission.UPDATE_BRANCH, true) {
-
             // check path parameters
             pathParams {
                 org()
@@ -94,7 +92,7 @@ fun Route.loadModel() {
                 // client did not explicitly provide a URL and the load service is configured
                 if(loadUrl == null && loadServiceUrl != null) {
                     // submit a POST request to the load service endpoint
-                    val response: HttpResponse = client.post("$loadServiceUrl/$diffId") {
+                    val response: HttpResponse = defaultHttpClient.post("$loadServiceUrl/$diffId") {
                         // TODO: verify load service request is correct and complete
                         // Pass received authorization to internal service
                         headers {
@@ -158,7 +156,7 @@ fun Route.loadModel() {
                     if(!RdfContentTypes.isTriples(modelContentType)) throw InvalidTriplesDocumentTypeException(modelContentType.toString())
 
                     // submit a PUT request to the quad-store's GSP endpoint
-                    val response: HttpResponse = client.put(application.quadStoreGraphStoreProtocolUrl!!) {
+                    val response: HttpResponse = defaultHttpClient.put(application.quadStoreGraphStoreProtocolUrl!!) {
                         // add the graph query parameter per the GSP specification
                         parameter("graph", loadGraphUri)
 

--- a/src/main/resources/application.conf.example
+++ b/src/main/resources/application.conf.example
@@ -11,6 +11,10 @@ mms {
         # patch strings above this threshold size will be gzipped when stored in the triplestore. if unset, will not attempt to gzip any strings (effectively disabling the feature)
         gzip-literals-larger-than-kib = 512
         gzip-literals-larger-than-kib = ${?MMS5_GZIP_LITERALS_LARGER_THAN_KIB}
+
+        # request timeout in seconds for requests to backend quadstore (default 30 min)
+        request-timeout = 1800
+        request-timeout = ${?MMS5_SPARQL_REQUEST_TIMEOUT}
     }
 
     load-service {

--- a/src/main/resources/application.conf.test
+++ b/src/main/resources/application.conf.test
@@ -6,6 +6,8 @@ mms {
         maximum-literal-size-kib = ${?MMS5_MAXIMUM_LITERAL_SIZE_KIB}
         gzip-literals-larger-than-kib = 512
         gzip-literals-larger-than-kib = ${?MMS5_GZIP_LITERALS_LARGER_THAN_KIB}
+        request-timeout = 1800
+        request-timeout = ${?MMS5_SPARQL_REQUEST_TIMEOUT}
     }
 
     load-service {


### PR DESCRIPTION
Adds `mms.application.request-timeout` config property to specify default client SPARQL request timeout in seconds.

This change will instantiate an HTTP client per incoming request, as opposed to using a single client for the entire application which is how it was done previously.

Addresses #120 