### PR TITLE
fix: remove duplicate prefixes

### DIFF
--- a/src/main/kotlin/org/openmbee/mms5/Model.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Model.kt
@@ -415,6 +415,7 @@ suspend fun MmsL1Context.queryModel(inputQueryString: String, refIri: String, co
             queryResponseText = executeSparqlSelectOrAsk(outputQueryString) {
                 acceptReplicaLag = true
 
+                prefixes(prefixes)
             }
         }
         catch(executeError: Exception) {
@@ -458,6 +459,7 @@ suspend fun MmsL1Context.queryModel(inputQueryString: String, refIri: String, co
         val queryResponseText = executeSparqlConstructOrDescribe(outputQueryString) {
             acceptReplicaLag = true
 
+            prefixes(prefixes)
         }
 
         call.respondText(queryResponseText, contentType=RdfContentTypes.Turtle)

--- a/src/main/kotlin/org/openmbee/mms5/Namespaces.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Namespaces.kt
@@ -39,7 +39,7 @@ class PrefixMapBuilder(other: PrefixMapBuilder?=null, setup: (PrefixMapBuilder.(
 
     override fun toString(): String {
         return map.entries.fold("") {
-            out, (key, value) -> out + "prefix $key: <$value>\n"
+            out, (key, value) -> out + "PREFIX $key: <$value>\n"
         }
     }
 

--- a/src/main/kotlin/org/openmbee/mms5/routes/endpoints/DiffQuery.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/endpoints/DiffQuery.kt
@@ -20,8 +20,8 @@ fun Route.queryDiff() {
 
             checkPrefixConflicts()
 
-            // auto-inject default prefixes
-            val inputQueryString = "$prefixes\n$requestBody"
+            // use request body for SPARQL query
+            val inputQueryString = requestBody
 
             queryModel(inputQueryString, prefixes["mord"]!!, DIFF_QUERY_CONDITIONS.append {
                 assertPreconditions(this) { "" }

--- a/src/main/kotlin/org/openmbee/mms5/routes/endpoints/LockQuery.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/endpoints/LockQuery.kt
@@ -16,8 +16,8 @@ fun Route.queryLock() {
 
             checkPrefixConflicts()
 
-            // auto-inject default prefixes
-            val inputQueryString = "$prefixes\n$requestBody"
+            // use request body for SPARQL query
+            val inputQueryString = requestBody
 
             queryModel(inputQueryString, prefixes["morl"]!!, LOCK_QUERY_CONDITIONS.append {
                 assertPreconditions(this) { "" }

--- a/src/main/kotlin/org/openmbee/mms5/routes/endpoints/ModelQuery.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/endpoints/ModelQuery.kt
@@ -18,8 +18,8 @@ fun Route.queryModel() {
 
             checkPrefixConflicts()
 
-            // auto-inject default prefixes
-            val inputQueryString = "$prefixes\n$requestBody"
+            // use request body for SPARQL query
+            val inputQueryString = requestBody
 
             queryModel(inputQueryString, prefixes["morb"]!!, BRANCH_QUERY_CONDITIONS.append {
                 assertPreconditions(this) { "" }

--- a/src/main/kotlin/org/openmbee/mms5/routes/endpoints/RepoQuery.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/endpoints/RepoQuery.kt
@@ -23,8 +23,8 @@ fun Route.queryRepo() {
 
             checkPrefixConflicts()
 
-            // auto-inject default prefixes
-            val inputQueryString = "$prefixes\n$requestBody"
+            // use request body for SPARQL query
+            val inputQueryString = requestBody
 
             queryModel(inputQueryString, prefixes["mor"]!!, REPO_QUERY_CONDITIONS.append {
                 assertPreconditions(this) { "" }

--- a/src/test/kotlin/org/openmbee/mms5/BranchCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/BranchCreate.kt
@@ -1,6 +1,5 @@
 package org.openmbee.mms5
 
-import io.kotest.core.spec.style.describeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.ktor.http.*
@@ -14,7 +13,7 @@ class BranchCreate : RefAny() {
         "reject invalid branch id".config(tags=setOf(NoAuth)) {
             withTest {
                 httpPut("/orgs/$orgId/repos/$repoId/branches/bad branch id") {
-                    setTurtleBody(validBranchBodyFromMaster)
+                    setTurtleBody(withAllTestPrefixes(validBranchBodyFromMaster))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.BadRequest
                 }
@@ -33,11 +32,11 @@ class BranchCreate : RefAny() {
                         var ref = "<> mms:ref <./master> ."
                         if (pred == "mms:ref")
                             ref = ""
-                        setTurtleBody("""
+                        setTurtleBody(withAllTestPrefixes("""
                             <> dct:title "$branchName"@en .
                             <> $pred $obj .
                             $ref
-                        """.trimIndent())
+                        """.trimIndent()))
                     }.apply {
                         response shouldHaveStatus HttpStatusCode.BadRequest
                     }
@@ -48,7 +47,7 @@ class BranchCreate : RefAny() {
         "create branch from master after a commit to master" {
             val update = commitModel(masterPath, """
                 insert data {
-                    <http://somesub.com> <http://somepred.com> 5 . 
+                    <mms:urn:s> <mms:urn:p> 5 . 
                 }
             """.trimIndent())
 
@@ -56,9 +55,7 @@ class BranchCreate : RefAny() {
 
             withTest {
                 httpPut(branchPath) {
-                    setTurtleBody("""
-                        $validBranchBodyFromMaster
-                    """.trimIndent())
+                    setTurtleBody(withAllTestPrefixes(validBranchBodyFromMaster))
                 }.apply {
                     validateCreateBranchResponse(commit!!)
                 }
@@ -68,9 +65,7 @@ class BranchCreate : RefAny() {
         "create branch from empty master" {
             withTest {
                 httpPut(branchPath) {
-                    setTurtleBody("""
-                        $validBranchBodyFromMaster
-                    """.trimIndent())
+                    setTurtleBody(withAllTestPrefixes(validBranchBodyFromMaster))
                 }.apply {
                     validateCreateBranchResponse(repoEtag)
                 }
@@ -120,11 +115,10 @@ class BranchCreate : RefAny() {
             withTest {
                 // create branch and validate
                 httpPut(branchPath) {
-                    setTurtleBody("""
+                    setTurtleBody(withAllTestPrefixes("""
                         ${title(branchName)}
                         <> mms:commit mor-commit:$restoreCommitId .
-                    """.trimIndent()
-                    )
+                    """.trimIndent()))
                 }.apply {
                     validateCreateBranchResponse(restoreCommitId)
                 }
@@ -171,10 +165,10 @@ class BranchCreate : RefAny() {
 
             withTest {
                 httpPut(branchPath) {
-                    setTurtleBody("""
+                    setTurtleBody(withAllTestPrefixes("""
                         ${title(branchName)}
                         <> mms:commit mor-commit:${commitId2} .
-                    """.trimIndent())
+                    """.trimIndent()))
                 }.apply {
                     validateCreateBranchResponse(commitId2)
                 }

--- a/src/test/kotlin/org/openmbee/mms5/BranchRead.kt
+++ b/src/test/kotlin/org/openmbee/mms5/BranchRead.kt
@@ -59,7 +59,7 @@ class BranchRead : RefAny() {
         "create from committed master then get all branches" {
             val update = commitModel(masterPath, """
                 insert data { 
-                    <http://somesub> <http://somepred> 5 .
+                    <urn:mms:s> <urn:mms:p> 5 .
                 }
             """.trimIndent())
 

--- a/src/test/kotlin/org/openmbee/mms5/BranchUpdate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/BranchUpdate.kt
@@ -14,18 +14,14 @@ class BranchUpdate : RefAny() {
 
             withTest {
                 httpPatch(branchPath) {
-                    setSparqlUpdateBody(
-                        """
-                        prefix foaf: <http://xmlns.com/foaf/0.1/>
-                        prefix dct: <http://purl.org/dc/terms/>
+                    setSparqlUpdateBody(withAllTestPrefixes("""
                         insert {
                             <> foaf:homepage <https://www.openmbee.org/> .
                         }
                         where {
                             <> dct:title "$branchName"@en .
                         }
-                    """.trimIndent()
-                    )
+                    """.trimIndent()))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
 

--- a/src/test/kotlin/org/openmbee/mms5/GroupCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/GroupCreate.kt
@@ -49,11 +49,11 @@ class GroupCreate : CommonSpec() {
     val groupPath = "/groups/${URLEncoder.encode(groupId, "UTF-8")}"
 
     val groupTitle = "Test Group"
-    val validGroupBody = """
+    val validGroupBody = withAllTestPrefixes("""
         <>
             dct:title "${groupTitle}"@en ;
             .
-    """.trimIndent()
+    """.trimIndent())
 
     init {
         "group id with slash".config(tags=setOf(NoAuth)) {

--- a/src/test/kotlin/org/openmbee/mms5/LockCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/LockCreate.kt
@@ -12,7 +12,7 @@ class LockCreate : LockAny() {
     fun createAndValidateLock(_lockId: String=lockId, lockBody: String=fromMaster) {
         withTest {
             httpPut("$repoPath/locks/$_lockId") {
-                setTurtleBody(lockBody)
+                setTurtleBody(withAllTestPrefixes(lockBody))
             }.apply {
                 response shouldHaveStatus HttpStatusCode.OK
 
@@ -31,7 +31,7 @@ class LockCreate : LockAny() {
         "reject invalid lock id".config(tags=setOf(NoAuth)) {
             withTest {
                 httpPut("$lockPath with invalid id") {
-                    setTurtleBody(fromMaster)
+                    setTurtleBody(withAllTestPrefixes(fromMaster))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.BadRequest
                 }

--- a/src/test/kotlin/org/openmbee/mms5/OrgCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/OrgCreate.kt
@@ -15,7 +15,7 @@ class OrgCreate : OrgAny() {
         "reject invalid org id".config(tags=setOf(NoAuth)) {
             withTest {
                 httpPut("$orgPath with invalid id") {
-                    setTurtleBody(validOrgBody)
+                    setTurtleBody(withAllTestPrefixes(validOrgBody))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.BadRequest
                 }
@@ -30,10 +30,10 @@ class OrgCreate : OrgAny() {
             "reject wrong $pred".config(tags=setOf(NoAuth)) {
                 withTest {
                     httpPut(orgPath) {
-                        setTurtleBody("""
+                        setTurtleBody(withAllTestPrefixes("""
                             $validOrgBody
                             <> $pred $obj .
-                        """.trimIndent())
+                        """.trimIndent()))
                     }.apply {
                         response shouldHaveStatus HttpStatusCode.BadRequest
                     }
@@ -44,7 +44,7 @@ class OrgCreate : OrgAny() {
         "create valid org" {
             withTest {
                 httpPut(orgPath) {
-                    setTurtleBody(validOrgBody)
+                    setTurtleBody(withAllTestPrefixes(validOrgBody))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
                     response.headers[HttpHeaders.ETag].shouldNotBeBlank()

--- a/src/test/kotlin/org/openmbee/mms5/OrgUpdate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/OrgUpdate.kt
@@ -14,18 +14,14 @@ class OrgUpdate : OrgAny() {
 
             withTest {
                 httpPatch(orgPath) {
-                    setSparqlUpdateBody("""
-                        prefix foaf: <http://xmlns.com/foaf/0.1/>
-                        prefix dct: <http://purl.org/dc/terms/>
-
+                    setSparqlUpdateBody(withAllTestPrefixes("""
                         insert {
                             <> foaf:homepage <https://www.openmbee.org/> .
                         }
                         where {
                             <> dct:title "$orgName"@en .
                         }
-                    """.trimIndent()
-                    )
+                    """.trimIndent()))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
 
@@ -45,18 +41,14 @@ class OrgUpdate : OrgAny() {
 
             withTest {
                 httpPatch(orgPath) {
-                    setSparqlUpdateBody("""                        
-                        prefix foaf: <http://xmlns.com/foaf/0.1/>
-                        prefix dct: <http://purl.org/dc/terms/>
-
+                    setSparqlUpdateBody(withAllTestPrefixes("""
                         insert {
                             <> foaf:homepage <https://www.openmbee.org/> .
                         }
                         where {
                             <> dct:title "Not $orgName"@en .
                         }
-                    """.trimIndent()
-                    )
+                    """.trimIndent()))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.PreconditionFailed
                 }

--- a/src/test/kotlin/org/openmbee/mms5/PolicyCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/PolicyCreate.kt
@@ -85,7 +85,7 @@ class PolicyCreate : CommonSpec() {
         "reject invalid policy id".config(tags=setOf(NoAuth)) {
             withTest {
                 httpPut("$policyPath with invalid id") {
-                    setTurtleBody(validPolicyBody)
+                    setTurtleBody(withAllTestPrefixes(validPolicyBody))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.BadRequest
                 }
@@ -99,10 +99,10 @@ class PolicyCreate : CommonSpec() {
             "reject wrong $pred".config(tags=setOf(NoAuth)) {
                 withTest {
                     httpPut(policyPath) {
-                        setTurtleBody("""
+                        setTurtleBody(withAllTestPrefixes("""
                             $validPolicyBody
                             <> $pred $obj .
-                        """.trimIndent())
+                        """.trimIndent()))
                     }.apply {
                         response shouldHaveStatus HttpStatusCode.BadRequest
                     }
@@ -113,7 +113,7 @@ class PolicyCreate : CommonSpec() {
         "create valid policy".config(tags=setOf(NoAuth)) {
             withTest {
                 httpPut(policyPath) {
-                    setTurtleBody(validPolicyBody)
+                    setTurtleBody(withAllTestPrefixes(validPolicyBody))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
                     response.headers[HttpHeaders.ETag].shouldNotBeBlank()

--- a/src/test/kotlin/org/openmbee/mms5/RepoCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/RepoCreate.kt
@@ -16,7 +16,7 @@ class RepoCreate : RepoAny() {
         "reject invalid repo id".config(tags=setOf(NoAuth)) {
             withTest {
                 httpPut("$repoPath with invalid id") {
-                    setTurtleBody(validRepoBody)
+                    setTurtleBody(withAllTestPrefixes(validRepoBody))
                 }.apply {
                     response shouldHaveStatus 400
                 }
@@ -26,10 +26,10 @@ class RepoCreate : RepoAny() {
         "create valid repo" {
             withTest {
                 httpPut(repoPath) {
-                    setTurtleBody("""
+                    setTurtleBody(withAllTestPrefixes("""
                         $validRepoBody
                         <> <$arbitraryPropertyIri> "$arbitraryPropertyValue" .
-                    """.trimIndent())
+                    """.trimIndent()))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
                     response.headers[HttpHeaders.ETag].shouldNotBeBlank()

--- a/src/test/kotlin/org/openmbee/mms5/RepoQuery.kt
+++ b/src/test/kotlin/org/openmbee/mms5/RepoQuery.kt
@@ -9,6 +9,8 @@ import org.openmbee.mms5.util.*
 class RepoQuery : ModelAny() {
 
     val lockCommitQuery = """
+        ${includePrefixes("mms")}
+
         select ?etag ?time where {
             ?lock mms:id "$lockId" .
             ?lock mms:commit ?commit .
@@ -25,7 +27,7 @@ class RepoQuery : ModelAny() {
             // lock should be pointing to the commit from update
             withTest {
                 httpPost("$repoPath/query") {
-                    setSparqlQueryBody(lockCommitQuery)
+                    setSparqlQueryBody(withAllTestPrefixes(lockCommitQuery))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
                     response.shouldHaveHeader("Content-Type", "application/sparql-results+json; charset=UTF-8")

--- a/src/test/kotlin/org/openmbee/mms5/RepoQuery.kt
+++ b/src/test/kotlin/org/openmbee/mms5/RepoQuery.kt
@@ -9,8 +9,6 @@ import org.openmbee.mms5.util.*
 class RepoQuery : ModelAny() {
 
     val lockCommitQuery = """
-        ${includePrefixes("mms")}
-
         select ?etag ?time where {
             ?lock mms:id "$lockId" .
             ?lock mms:commit ?commit .

--- a/src/test/kotlin/org/openmbee/mms5/RepoUpdate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/RepoUpdate.kt
@@ -14,18 +14,14 @@ class RepoUpdate : RepoAny() {
 
             withTest {
                 httpPatch(repoPath) {
-                    setSparqlUpdateBody("""
-                        prefix foaf: <http://xmlns.com/foaf/0.1/>
-                        prefix dct: <http://purl.org/dc/terms/>
-
+                    setSparqlUpdateBody(withAllTestPrefixes("""
                         insert {
                             <> foaf:homepage <https://www.openmbee.org/> .
                         }
                         where {
                             <> dct:title "$repoName"@en .
                         }
-                    """.trimIndent()
-                    )
+                    """.trimIndent()))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.OK
 
@@ -48,18 +44,14 @@ class RepoUpdate : RepoAny() {
 
             withTest {
                 httpPatch(repoPath) {
-                    setSparqlUpdateBody("""
-                        prefix foaf: <http://xmlns.com/foaf/0.1/>
-                        prefix dct: <http://purl.org/dc/terms/>
-
+                    setSparqlUpdateBody(withAllTestPrefixes("""
                         insert {
                             <> foaf:homepage <https://www.openmbee.org/> .
                         }
                         where {
                             <> dct:title "Not $repoName"@en .
                         }
-                    """.trimIndent()
-                    )
+                    """.trimIndent()))
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.PreconditionFailed
                 }

--- a/src/test/kotlin/org/openmbee/mms5/util/Helper.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/Helper.kt
@@ -1,12 +1,8 @@
 package org.openmbee.mms5.util
 
 import io.ktor.http.*
-import io.ktor.server.request.*
 import io.ktor.server.testing.*
-import org.apache.jena.rdf.model.Model
-import org.openmbee.mms5.KModel
-import org.openmbee.mms5.RdfContentTypes
-import org.openmbee.mms5.parseTurtle
+import org.openmbee.mms5.*
 
 
 fun createOrg(orgId: String, orgName: String): TestApplicationCall {
@@ -82,3 +78,30 @@ fun loadModel(refPath: String, turtle: String): TestApplicationCall {
     }
 }
 
+fun includePrefixes(vararg prefixKeys: String, extraSetup: (PrefixMapBuilder.() -> Unit)?=null): String {
+    return PrefixMapBuilder().apply {
+        add(*SPARQL_PREFIXES.map.filterKeys {
+            it in prefixKeys
+        }.toList().toTypedArray())
+
+        extraSetup?.invoke(this)
+    }.toString()
+}
+
+fun includeAllTestPrefixes(extraSetup: (PrefixMapBuilder.() -> Unit)?=null): String {
+    return includePrefixes("rdf", "rdfs", "dct", "xsd", "mms") {
+        add(
+            "foaf" to "http://xmlns.com/foaf/0.1/"
+        )
+
+        extraSetup?.invoke(this)
+    }
+}
+
+fun withAllTestPrefixes(body: String): String {
+    return """
+        ${includeAllTestPrefixes()}
+        
+        $body
+    """.trimIndent()
+}


### PR DESCRIPTION
Makes prefix injection consistent for all endpoints, preventing duplicates. Consequently, default prefixes will no longer autofill user SPARQL queries. This required updating the test suite.

Closes #124 