### PR TITLE
feat: Support Extra User Query Types

### DIFF
--- a/src/main/kotlin/org/openmbee/mms5/Model.kt
+++ b/src/main/kotlin/org/openmbee/mms5/Model.kt
@@ -231,7 +231,7 @@ suspend fun MmsL1Context.processAndSubmitUserQuery(inputQueryString: String, ref
 
     // prepare a query to check required conditions and select the appropriate target graph if necessary
     val serviceQuery = """
-        select * where {
+        select ?targetGraph ?satisfied where {
             ${if(targetGraphIri != null) """
                 bind(<$targetGraphIri> as ?targetGraph)
             """.reindent(3) else """

--- a/src/main/kotlin/org/openmbee/mms5/routes/endpoints/CollectionQuery.kt
+++ b/src/main/kotlin/org/openmbee/mms5/routes/endpoints/CollectionQuery.kt
@@ -25,16 +25,16 @@ fun Route.queryCollection() {
 
             checkPrefixConflicts()
 
-            val (rewriter, outputQuery) = sanitizeUserQuery(requestBody)
-
-            // outputQuery.graphURIs.
-
-            // TODO construct query that joins
-            outputQuery.apply {
-                // set default graph
-                graphURIs.clear()
-                // graphURIs.addAll()
-            }.queryPattern.toString()
+//            val (rewriter, outputQuery) = sanitizeUserQuery(requestBody)
+//
+//            // outputQuery.graphURIs.
+//
+//            // TODO construct query that joins
+//            outputQuery.apply {
+//                // set default graph
+//                graphURIs.clear()
+//                // graphURIs.addAll()
+//            }.queryPattern.toString()
         }
 
     }

--- a/src/test/kotlin/org/openmbee/mms5/BranchRead.kt
+++ b/src/test/kotlin/org/openmbee/mms5/BranchRead.kt
@@ -39,8 +39,6 @@ class BranchRead : RefAny() {
         "get master branch" {
             withTest {
                 httpGet(masterPath) {}.apply {
-                    response shouldHaveStatus HttpStatusCode.OK
-
                     response includesTriples {
                         val branchiri = localIri(masterPath)
 
@@ -67,8 +65,6 @@ class BranchRead : RefAny() {
 
             withTest {
                 httpGet("$repoPath/branches") {}.apply {
-                    response shouldHaveStatus HttpStatusCode.OK
-
                     response includesTriples  {
                         subject(localIri(branchPath)) {
                             includes(

--- a/src/test/kotlin/org/openmbee/mms5/BranchUpdate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/BranchUpdate.kt
@@ -23,8 +23,6 @@ class BranchUpdate : RefAny() {
                         }
                     """.trimIndent()))
                 }.apply {
-                    response shouldHaveStatus HttpStatusCode.OK
-
                     response includesTriples {
                         subject(localIri(branchPath)) {
                             includes(

--- a/src/test/kotlin/org/openmbee/mms5/GroupCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/GroupCreate.kt
@@ -99,7 +99,6 @@ class GroupCreate : CommonSpec() {
                 httpPut(groupPath) {
                     setTurtleBody(validGroupBody)
                 }.apply {
-                    response shouldHaveStatus HttpStatusCode.OK
                     response.headers[HttpHeaders.ETag].shouldNotBeBlank()
 
                     response includesTriples  {

--- a/src/test/kotlin/org/openmbee/mms5/LockCreate.kt
+++ b/src/test/kotlin/org/openmbee/mms5/LockCreate.kt
@@ -14,8 +14,6 @@ class LockCreate : LockAny() {
             httpPut("$repoPath/locks/$_lockId") {
                 setTurtleBody(withAllTestPrefixes(lockBody))
             }.apply {
-                response shouldHaveStatus HttpStatusCode.OK
-
                 val etag = response.headers[HttpHeaders.ETag]
                 etag.shouldNotBeBlank()
 

--- a/src/test/kotlin/org/openmbee/mms5/LockQuery.kt
+++ b/src/test/kotlin/org/openmbee/mms5/LockQuery.kt
@@ -1,8 +1,13 @@
 package org.openmbee.mms5
 
 import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.assertions.json.shouldMatchJson
 
 import io.ktor.http.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.openmbee.mms5.util.*
 
 class LockQuery : LockAny() {
@@ -38,6 +43,146 @@ class LockQuery : LockAny() {
                             }
                         }
                     """.trimIndent())
+                }
+            }
+        }
+
+        "query lock with graph var" {
+            commitModel(masterPath, insertLock)
+            createLock(repoPath, masterPath, lockId)
+
+            withTest {
+                httpPost("$lockPath/query") {
+                    setSparqlQueryBody("""
+                        select ?g ?o {
+                            graph ?g {
+                                <urn:mms:s> <urn:mms:p> ?o .
+                            }
+                        }
+                    """.trimIndent())
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+
+                    val graphVal = Json.parseToJsonElement(response.content!!).jsonObject["results"]!!
+                        .jsonObject["bindings"]!!.jsonArray[0].jsonObject["g"]!!.jsonObject["value"]!!
+                        .jsonPrimitive.content;
+
+                    response.content!!.shouldEqualJson("""
+                        {
+                            "head": {
+                                "vars": ["g", "o"]
+                            },
+                            "results": {
+                                "bindings": [
+                                    {
+                                        "g": {
+                                            "type": "uri",
+                                            "value": "$graphVal"
+                                        },
+                                        "o": {
+                                            "type": "uri",
+                                            "value": "urn:mms:o"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    """.trimIndent())
+                }
+            }
+        }
+
+        "ask lock" {
+            commitModel(masterPath, insertLock)
+            createLock(repoPath, masterPath, lockId)
+
+            withTest {
+                httpPost("$lockPath/query") {
+                    setSparqlQueryBody("""
+                        ask {
+                            <urn:mms:s> <urn:mms:p> ?o .
+                        }
+                    """.trimIndent())
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+
+                    response.content!!.shouldEqualJson("""
+                        {
+                            "head": {},
+                            "boolean": true
+                        }
+                    """.trimIndent())
+                }
+            }
+        }
+
+        "describe lock explicit" {
+            commitModel(masterPath, insertLock)
+            createLock(repoPath, masterPath, lockId)
+
+            withTest {
+                httpPost("$lockPath/query") {
+                    setSparqlQueryBody("""
+                        describe <urn:mms:s>
+                    """.trimIndent())
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+
+                    response includesTriples {
+                        subject("urn:mms:s") {
+                            ignoreAll()
+                        }
+                    }
+                }
+            }
+        }
+
+        "describe lock where" {
+            commitModel(masterPath, insertLock)
+            createLock(repoPath, masterPath, lockId)
+
+            withTest {
+                httpPost("$lockPath/query") {
+                    setSparqlQueryBody("""
+                        describe ?s {
+                            ?s <urn:mms:p> <urn:mms:o> .
+                        }
+                    """.trimIndent())
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+
+                    response includesTriples {
+                        subject("urn:mms:s") {
+                            ignoreAll()
+                        }
+                    }
+                }
+            }
+        }
+
+        "construct lock" {
+            commitModel(masterPath, insertLock)
+            createLock(repoPath, masterPath, lockId)
+
+            withTest {
+                httpPost("$lockPath/query") {
+                    setSparqlQueryBody("""
+                        construct {
+                            ?o ?p ?s .
+                        } where {
+                            ?s ?p ?o .
+                        }
+                    """.trimIndent())
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+
+                    response exclusivelyHasTriples  {
+                        subject("urn:mms:o") {
+                            exclusivelyHas(
+                                "urn:mms:p".toPredicate exactly "urn:mms:s".iri
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/org/openmbee/mms5/LockRead.kt
+++ b/src/test/kotlin/org/openmbee/mms5/LockRead.kt
@@ -35,8 +35,6 @@ class LockRead : LockAny() {
 
             withTest {
                 httpGet(lockPath) {}.apply {
-                    response shouldHaveStatus HttpStatusCode.OK
-
                     response includesTriples {
                         thisLockTriples(lockId, etag!!)
                     }

--- a/src/test/kotlin/org/openmbee/mms5/ModelAny.kt
+++ b/src/test/kotlin/org/openmbee/mms5/ModelAny.kt
@@ -1,18 +1,22 @@
 package org.openmbee.mms5
 
-import io.kotest.assertions.json.shouldBeJsonObject
-import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.matchers.string.shouldStartWith
-import io.ktor.http.*
-import io.ktor.server.testing.*
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.XSD
 import org.openmbee.mms5.util.*
 
 open class ModelAny: RefAny() {
+    val demoPrefixes = PrefixMapBuilder().apply {
+        add(
+            "" to "https://mms.openmbee.org/demos/people/",
+            "foaf" to "http://xmlns.com/foaf/0.1/",
+        )
+    }
+
+    val demoPrefixesStr = demoPrefixes.toString()
+
     val insertAliceRex = """
-        prefix : <https://mms.openmbee.org/demos/people/>
-        prefix foaf: <http://xmlns.com/foaf/0.1/>
+        $demoPrefixesStr
+
         insert data {
             :Alice a :Person ;
                 foaf:name "Alice" ;
@@ -27,8 +31,8 @@ open class ModelAny: RefAny() {
     """.trimIndent()
 
     val insertBobFluffy = """
-        prefix : <https://mms.openmbee.org/demos/people/>
-        prefix foaf: <http://xmlns.com/foaf/0.1/>
+        $demoPrefixesStr
+
         insert data {
             :Bob a :Person ;
                 foaf:name "Bob" ;
@@ -42,15 +46,9 @@ open class ModelAny: RefAny() {
         }
     """.trimIndent()
 
-    val sparqlQueryAll = """
-        select * where {
-            ?s ?p ?o
-        }
-    """.trimIndent()
-
     val queryNames = """
-        prefix : <https://mms.openmbee.org/demos/people/>
-        prefix foaf: <http://xmlns.com/foaf/0.1/>
+        $demoPrefixesStr
+
         select ?name where {
             ?s a :Person .
             ?s foaf:name ?name .
@@ -103,29 +101,8 @@ open class ModelAny: RefAny() {
         }
     """.trimIndent()
 
-    val queryNamesBobResult = """
-        {
-            "head": {
-                "vars": [
-                    "name"
-                ]
-            },
-            "results": {
-                "bindings": [
-                    {
-                        "name": {
-                            "type": "literal",
-                            "value": "Bob"
-                        }
-                    }
-                ]
-            }
-        }
-    """.trimIndent()
-
     val loadAliceRex = """
-        @prefix : <https://mms.openmbee.org/demos/people/>
-        @prefix foaf: <http://xmlns.com/foaf/0.1/>
+        $demoPrefixesStr
 
         :Alice a :Person ;
             foaf:name "Alice" .
@@ -136,8 +113,7 @@ open class ModelAny: RefAny() {
     """.trimIndent()
 
     val loadBobFluffy = """
-        @prefix : <https://mms.openmbee.org/demos/people/>
-        @prefix foaf: <http://xmlns.com/foaf/0.1/>
+        $demoPrefixesStr
 
         :Bob a :Person ;
             foaf:name "Bob" .

--- a/src/test/kotlin/org/openmbee/mms5/ModelCommit.kt
+++ b/src/test/kotlin/org/openmbee/mms5/ModelCommit.kt
@@ -9,12 +9,10 @@ fun ModelCommit.commitAndValidateModel(branchPath: String) {
         httpPost("$branchPath/update") {
             setSparqlUpdateBody(insertAliceRex)
         }.apply {
-            response shouldHaveStatus HttpStatusCode.Created
-
             val etag = response.headers[HttpHeaders.ETag]
             etag.shouldNotBeBlank()
 
-            response exclusivelyHasTriples {
+            response.exclusivelyHasTriples(HttpStatusCode.Created) {
                 validateModelCommitResponse(branchPath, etag!!)
             }
         }

--- a/src/test/kotlin/org/openmbee/mms5/ModelQuery.kt
+++ b/src/test/kotlin/org/openmbee/mms5/ModelQuery.kt
@@ -50,6 +50,69 @@ class ModelQuery : ModelAny() {
             }
         }
 
+        "query model with from default not authorized" {
+            commitModel(masterPath, insertAliceRex)
+
+            withTest {
+                // master model is updated
+                httpPost("$masterPath/query") {
+                    setSparqlQueryBody(withAllTestPrefixes("""
+                        select *
+                            from m-graph:AccessControl.Policies
+                        {
+                            ?s ?p ?o
+                        }
+                    """.trimIndent()))
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Forbidden
+                }
+            }
+        }
+
+        "query model with from named not authorized" {
+            commitModel(masterPath, insertAliceRex)
+
+            withTest {
+                // master model is updated
+                httpPost("$masterPath/query") {
+                    setSparqlQueryBody(withAllTestPrefixes("""
+                        select *
+                            from named m-graph:AccessControl.Policies
+                        {
+                            graph ?g {
+                                ?s ?p ?o
+                            }
+                        }
+                    """.trimIndent()))
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Forbidden
+                }
+            }
+        }
+
+        "query model graph not there" {
+            commitModel(masterPath, insertAliceRex)
+
+            withTest {
+                // master model is updated
+                httpPost("$masterPath/query") {
+                    setSparqlQueryBody(withAllTestPrefixes("""
+                        select * {
+                            graph m-graph:AccessControl.Policies {
+                                ?s ?p ?o
+                            }
+                        }
+                    """.trimIndent()))
+                }.apply {
+                    response equalsSparqlResults {
+                        varsExpect.addAll(listOf(
+                            "s", "p", "o"
+                        ))
+                    }
+                }
+            }
+        }
+
         "ask model: true" {
             commitModel(masterPath, insertAliceRex)
 

--- a/src/test/kotlin/org/openmbee/mms5/RefAny.kt
+++ b/src/test/kotlin/org/openmbee/mms5/RefAny.kt
@@ -35,7 +35,6 @@ open class RefAny : RepoAny() {
     }
 
     fun TestApplicationCall.validateCreateBranchResponse(fromCommit: String) {
-        response shouldHaveStatus HttpStatusCode.OK
         response.headers[HttpHeaders.ETag].shouldNotBeBlank()
 
         response exclusivelyHasTriples {

--- a/src/test/kotlin/org/openmbee/mms5/util/Helper.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/Helper.kt
@@ -89,7 +89,15 @@ fun includePrefixes(vararg prefixKeys: String, extraSetup: (PrefixMapBuilder.() 
 }
 
 fun includeAllTestPrefixes(extraSetup: (PrefixMapBuilder.() -> Unit)?=null): String {
-    return includePrefixes("rdf", "rdfs", "dct", "xsd", "mms") {
+    return includePrefixes(
+        "rdf",
+        "rdfs",
+        "dct",
+        "xsd",
+        "mms",
+        "m",
+        "m-graph",
+    ) {
         add(
             "foaf" to "http://xmlns.com/foaf/0.1/"
         )

--- a/src/test/kotlin/org/openmbee/mms5/util/JsonAssertions.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/JsonAssertions.kt
@@ -1,0 +1,111 @@
+package org.openmbee.mms5.util
+
+import io.kotest.assertions.fail
+import io.kotest.assertions.json.shouldBeJsonObject
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import kotlinx.serialization.json.*
+import org.openmbee.mms5.RdfContentTypes
+
+/**
+ * Converts a string into a binding result literal JsonElement
+ */
+var String.bindingLit: JsonElement
+    get() = JsonObject(mapOf(
+        "type" to JsonPrimitive("literal"),
+        "value" to JsonPrimitive(this),
+    ))
+    set(v) {}
+
+/**
+ * Converts a string into a binding result uri JsonElement
+ */
+var String.bindingUri: JsonElement
+    get() = JsonObject(mapOf(
+        "type" to JsonPrimitive("uri"),
+        "value" to JsonPrimitive(this),
+    ))
+    set(v) {}
+
+class JsonAsserter(json: JsonElement, var resultsName: String="Unnamed") {
+    private val varsActual = json.jsonObject["head"]!!.jsonObject["vars"]!!.jsonArray.toTypedArray()
+        .map { it.jsonPrimitive.content }.toCollection(ArrayList())
+
+    private val bindingsActual = json.jsonObject["results"]!!.jsonObject["bindings"]!!.jsonArray.toTypedArray()
+        .toCollection(ArrayList())
+
+    private val varsExpect = hashSetOf<String>()
+    private val bindings = arrayListOf<JsonObject>()
+
+    /**
+     * Asserts the given binding is next in the expected results JSON, and checks the variable names is in head
+     */
+    fun binding(vararg pairs: Pair<String, JsonElement>) {
+        val row = hashMapOf<String, JsonElement>()
+
+        // each pair in assertion
+        for((varName, element) in pairs) {
+            // add to expected set
+            varsExpect.add(varName)
+
+            // check var is present in actual
+            varsActual.shouldContain(varName)
+
+            // save element to hash map
+            row[varName] = element
+        }
+
+        // assert the next element equals this binding
+        bindingsActual[0].toString() shouldBe JsonObject(row).toString()
+
+        // remove matched binding
+        bindingsActual.removeFirst()
+    }
+
+    /**
+     * Asserts no other bindings exist in the results
+     */
+    fun assertBindingsEmpty() {
+        if(bindingsActual.isNotEmpty()) {
+            fail("\"$resultsName\" SPARQL results JSON has extraneous bindings:\n"+bindingsActual.joinToString(",\n") { it.toString() })
+        }
+    }
+
+    /**
+     * Asserts no other vars exist in "head"
+     */
+    fun assertVarsCovered() {
+        for(varName in varsActual) {
+            if(!varsExpect.contains(varName)) {
+                fail("\"$resultsName\" SPARQL results JSON has extraneous variable in \"head\": $varName")
+            }
+        }
+    }
+
+    fun assertExclusive() {
+        assertBindingsEmpty()
+        assertVarsCovered()
+    }
+}
+
+infix fun TestApplicationResponse.equalsSparqlResults(build: JsonAsserter.() -> Unit) {
+    this shouldHaveStatus HttpStatusCode.OK
+
+    // assert content-type header (ignore charset if present)
+    this.headers[HttpHeaders.ContentType].shouldStartWith(RdfContentTypes.SparqlResultsJson.contentType)
+
+    // load str
+    val jsonStr = this.content.toString()
+
+    // json object
+    jsonStr.shouldBeJsonObject()
+
+    // parse
+    val jsonObj = Json.parseToJsonElement(jsonStr)
+
+    // apply assertions
+    JsonAsserter(jsonObj).apply { build() }.assertExclusive()
+}

--- a/src/test/kotlin/org/openmbee/mms5/util/JsonAssertions.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/JsonAssertions.kt
@@ -37,7 +37,7 @@ class JsonAsserter(json: JsonElement, var resultsName: String="Unnamed") {
     private val bindingsActual = json.jsonObject["results"]!!.jsonObject["bindings"]!!.jsonArray.toTypedArray()
         .toCollection(ArrayList())
 
-    private val varsExpect = hashSetOf<String>()
+    val varsExpect = hashSetOf<String>()
     private val bindings = arrayListOf<JsonObject>()
 
     /**

--- a/src/test/kotlin/org/openmbee/mms5/util/RdfAssertions.kt
+++ b/src/test/kotlin/org/openmbee/mms5/util/RdfAssertions.kt
@@ -243,16 +243,6 @@ class SubjectContext(modelContext: ModelContext, val subject: Resource) {
     fun removeRest() {
         model.removeAll(subject, null, null)
     }
-
-    /**
-     * Asserts the subject exists (i.e., that is has at least one statement)
-     */
-    fun assertExists() {
-        val others = subject.listProperties()
-        if(!others.hasNext()) {
-            fail("\"$modelName\" model is missing triples for subject $subject:")
-        }
-    }
 }
 
 
@@ -281,10 +271,6 @@ class SubjectHandle(modelContext: ModelContext, subject: Resource) {
 
     fun ignoreAll() {
         subjectContext.removeRest()
-    }
-
-    fun exists() {
-        subjectContext.assertExists()
     }
 }
 


### PR DESCRIPTION
Introduces a feature that allows users to submit `ASK`, `CONSTRUCT`, and `DESCRIBE` SPARQL queries against ModelQuery and LockQuery endpoints.

Additionally, this PR abandons the previous graph scoping approach (which wrapped user query in a `GRAPH { .. }` block) in favor of using `FROM` and `FROM NAMED` since user queries no longer co-occur with service queries, and thus they do not need to be sanitized, they only need to be limited to the target graph(s). This greatly simplifies the query transformation and allows user queries to be much more transparent.